### PR TITLE
Implement more assignment operators

### DIFF
--- a/tests/language-basics/language-basics.go
+++ b/tests/language-basics/language-basics.go
@@ -1,0 +1,33 @@
+//
+// Copyright 2016 Leandro Pereira <leandro@tia.mat.br>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package main
+
+func assignOps() {
+	someVar := 6 * 7
+	someVar += 1
+	someVar -= 1
+	someVar *= 1
+	someVar /= 1
+	someVar %= 1
+	someVar &= 1
+	someVar |= 1
+	someVar ^= 1
+	someVar <<= 1
+	someVar >>= 1
+	someVar &^= 1
+	someVar = 1
+}

--- a/tests/language-basics/language-basics.ino
+++ b/tests/language-basics/language-basics.ino
@@ -1,0 +1,15 @@
+void assignOps() {
+  auto someVar = 6*7;
+  someVar += 1;
+  someVar -= 1;
+  someVar *= 1;
+  someVar /= 1;
+  someVar %= 1;
+  someVar &= 1;
+  someVar |= 1;
+  someVar ^= 1;
+  someVar <<= 1;
+  someVar >>= 1;
+  someVar &= ~(1);
+  someVar = 1;
+}

--- a/tests/language-basics/main.go
+++ b/tests/language-basics/main.go
@@ -1,0 +1,21 @@
+//
+// Copyright 2016 Leandro Pereira <leandro@tia.mat.br>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package main
+
+func main() {
+	assignOps()
+}

--- a/transpiler/transpiler_test.go
+++ b/transpiler/transpiler_test.go
@@ -15,17 +15,22 @@ var sketches = []string{
 	"fade",
 }
 
-const sketchDir = "../sketches"
+var tests = []string{
+	"language-basics",
+}
 
-func TestSketches(t *testing.T) {
-	for _, s := range sketches {
-		g, err := os.Open(filepath.Join(sketchDir, s, s+".go"))
+const sketchDir = "../sketches"
+const testDir = "../tests"
+
+func runTests(t *testing.T, testList []string, testDir string) {
+	for _, s := range testList {
+		g, err := os.Open(filepath.Join(testDir, s, s+".go"))
 		if err != nil {
 			t.Errorf("failed to open %s.go: %v", s, err)
 			continue
 		}
 		defer g.Close()
-		bs, err := ioutil.ReadFile(filepath.Join(sketchDir, s, s+".ino"))
+		bs, err := ioutil.ReadFile(filepath.Join(testDir, s, s+".ino"))
 		if err != nil {
 			t.Errorf("failed to read %s.ino: %v", s, err)
 			continue
@@ -40,7 +45,14 @@ func TestSketches(t *testing.T) {
 			t.Errorf("expected:\n%s-- got:\n%s", ino, out.String())
 		}
 	}
+}
 
+func TestTests(t *testing.T) {
+	runTests(t, tests, testDir)
+}
+
+func TestSketches(t *testing.T) {
+	runTests(t, sketches, sketchDir)
 }
 
 func nospace(s string) string {


### PR DESCRIPTION
This generates code for all of the assignment operators available for assignment statements.  This includes shortcuts such as "+=" or "%=", and also the definition+assignment operator, ":=".  In the latter case, C++'s "auto" keyword is used to infer the type.

Closes #11.
