### PR TITLE
Travis: Build with 1.6+tip, run gofmt, go vet, go test -race checks.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,1 +1,16 @@
+sudo: false
 language: go
+go:
+  - 1.6.2
+  - tip
+matrix:
+  allow_failures:
+    - go: tip
+  fast_finish: true
+install:
+  - # Do nothing. This is needed to prevent default install action "go get -t -v ./..." from happening here (we want it to happen inside script step).
+script:
+  - go get -t -v ./...
+  - diff -u <(echo -n) <(gofmt -d -s .)
+  - go tool vet .
+  - go test -v -race ./...


### PR DESCRIPTION
Make tip a fast-finish allowed failure. That way, if CI fails on tip due to a temporary issue with tip, it will not break build status. However, it's still possible to see tip build status by looking at CI details page.

This is a followup to #13. The default Travis configuration is not very thorough, and skips many useful checks. This adds some of those.

It's modeled after https://github.com/google/go-github/blob/0af232a73d5e33ea92bd7f6d3efab510c4780856/.travis.yml.
