### PR TITLE
Improve error message handling.

### DIFF
--- a/transpiler/transpiler.go
+++ b/transpiler/transpiler.go
@@ -29,23 +29,19 @@ import (
 
 // Transpile reads Go source code from the given Reader and writes the
 // transpiled Arduino C++ code to the given Writer.
-func Transpile(out io.Writer, in io.Reader, debug io.Writer) error {
+func Transpile(out io.Writer, in io.Reader) (*ast.File, error) {
 	fset := token.NewFileSet()
 	f, err := parser.ParseFile(fset, "sketch.go", in, 0)
 	if err != nil {
-		return fmt.Errorf("failed to parse file: %v", err)
-	}
-
-	if debug != nil {
-		ast.Fprint(debug, fset, f, nil)
+		return nil, fmt.Errorf("failed to parse file: %s", err)
 	}
 
 	for _, d := range f.Decls {
 		if err := handleDecl(out, d); err != nil {
-			return fmt.Errorf("error handling decl %#v: %v", d, err)
+			return f, fmt.Errorf("error handling decl %#v: %s", d, err)
 		}
 	}
-	return nil
+	return f, nil
 }
 
 func handleDecl(out io.Writer, d ast.Decl) error {

--- a/transpiler/transpiler_test.go
+++ b/transpiler/transpiler_test.go
@@ -32,7 +32,7 @@ func TestSketches(t *testing.T) {
 		}
 		ino := string(bs)
 		var out bytes.Buffer
-		if err := Transpile(&out, g, nil); err != nil {
+		if _, err := Transpile(&out, g); err != nil {
 			t.Errorf("failed to transpile sketch %q: %v", s, err)
 			continue
 		}

--- a/µ.go
+++ b/µ.go
@@ -14,17 +14,43 @@
 // limitations under the License.
 //
 
+// mugo transpiles a subset of the Go language to C++.
+//
+// See package transpiler for more details.
 package main
 
 import (
+	"errors"
+	"flag"
+	"fmt"
+	"go/ast"
+	"io/ioutil"
 	"log"
 	"os"
 
 	"github.com/googlesamples/mugo/transpiler"
 )
 
+func mainImpl() error {
+	verbose := flag.Bool("verbose", false, "log data")
+	flag.Parse()
+	if flag.NArg() != 0 {
+		return errors.New("unexpected arguments")
+	}
+	if !*verbose {
+		log.SetOutput(ioutil.Discard)
+	}
+	f, err := transpiler.Transpile(os.Stdout, os.Stdin)
+	os.Stdout.Sync()
+	if *verbose {
+		ast.Fprint(os.Stderr, nil, f, nil)
+	}
+	return err
+}
+
 func main() {
-	if err := transpiler.Transpile(os.Stdout, os.Stdin, os.Stderr); err != nil {
-		log.Fatalf("failed to transpile: %v", err)
+	if err := mainImpl(); err != nil {
+		fmt.Fprintf(os.Stderr, "mugo: %s\n", err)
+		os.Exit(1)
 	}
 }


### PR DESCRIPTION
Change Transpile() to return an ast.File instead of printing from within the
function.

This is the first part of the big PR.
